### PR TITLE
humanagent-mcp: v0.0.18 fix /response, add lifecycle shutdown, avoid update locks

### DIFF
--- a/README-Additional.md
+++ b/README-Additional.md
@@ -6,7 +6,7 @@ VS Code extension that creates an MCP server for AI assistants to chat with huma
 
 ![HumanAgent MCP Extension Demo](high-res-demo.gif)
 
-*Complete demonstration of the HumanAgent MCP extension in action - showing real-time human-AI collaboration*
+_Complete demonstration of the HumanAgent MCP extension in action - showing real-time human-AI collaboration_
 
 ## What it does
 
@@ -14,7 +14,7 @@ This extension provides a `HumanAgent_Chat` MCP tool that forces AI assistants t
 
 ## Why
 
-The AI Agent is encouraged to discuss with you before running off to do its own thing - if its part way through iterating through on a problem it can stop and ask you a question - it reduces requests considerably, helps avoid runaway agent, allows you to manage multiple VSCode agents working in multiple workspaces from one web page. Allows you to append useful reminders to each response.   
+The AI Agent is encouraged to discuss with you before running off to do its own thing - if its part way through iterating through on a problem it can stop and ask you a question - it reduces requests considerably, helps avoid runaway agent, allows you to manage multiple VSCode agents working in multiple workspaces from one web page. Allows you to append useful reminders to each response.
 
 ## How it works
 
@@ -23,6 +23,12 @@ The AI Agent is encouraged to discuss with you before running off to do its own 
 - AI assistants must use this tool for all interactions
 - Creates persistent chat sessions with message history
 - Provides VS Code webview and browser interfaces for human responses
+
+### Server Lifecycle
+
+- The server stops automatically when VS Code closes (so the port doesn’t remain occupied).
+- Reloading the VS Code window restarts the server automatically.
+- The standalone server is launched from VS Code `globalStorage` to avoid extension-update file locks.
 
 ## Installation and Setup
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ Forces GitHub Copilot to chat with you before acting. Stops runaway agents, redu
 ### VS Code Interface
 
 **Chat Panel** (left sidebar):
+
 - Green dot = connected to server
 - Red dot = disconnected (auto-reconnects)
 - Quick Replies = common responses like "Yes Please Proceed"
 - Text input = always enabled, send button only active when Copilot is waiting
 
 **Cog Menu** (⚙️):
+
 - Show Status - check server state
 - Name This Chat - set session name
 - Open Web View - manage all workspaces in browser
@@ -37,6 +39,7 @@ Forces GitHub Copilot to chat with you before acting. Stops runaway agents, redu
 Open from cog menu → **Open Web View**
 
 Access all workspace chats in one browser tab at `http://localhost:3737/HumanAgent`
+
 - See all conversations
 - Switch between workspaces
 - Append reminders to your responses
@@ -47,17 +50,27 @@ Access all workspace chats in one browser tab at `http://localhost:3737/HumanAge
 - Manually starting server resets reconnection immediately
 - No timeout - will retry forever
 
+### Server Lifecycle
+
+- Server stops automatically when VS Code closes (prevents port 3737/3738 being left occupied)
+- Server restarts automatically when you reload the VS Code window
+
 ## Troubleshooting
 
 **Red dot / disconnected:**
+
 - Cog menu → Configure MCP → Start Server
 - Check VS Code Output panel for errors
 
 **Server won't start:**
-- Check port 3737 not in use: `lsof -i :3737`
+
+- Check port 3737 not in use:
+  - macOS/Linux: `lsof -i :3737`
+  - Windows (PowerShell): `netstat -ano | findstr :3737`
 - Restart VS Code
 
 **Copilot not using the tool:**
+
 - Tool registers automatically on startup
 - Try: "Use HumanAgent_Chat to discuss this with me"
 
@@ -70,6 +83,7 @@ Press F5 to debug - dev mode uses port 3738, production uses 3737. No conflicts.
 This extension collects **anonymous usage data** to help improve the product:
 
 **What we track:**
+
 - Extension activation/deactivation
 - Feature usage (chat opened, messages sent/received)
 - Error diagnostics (error types, not content)
@@ -78,18 +92,21 @@ This extension collects **anonymous usage data** to help improve the product:
 - Days since installation
 
 **What we DON'T track:**
+
 - ❌ Your message content
 - ❌ Your name, email, or any personal data
 - ❌ Workspace paths or file names
 - ❌ Any identifiable information
 
 **Your privacy:**
+
 - Respects VS Code's telemetry setting
 - To disable: Settings → Telemetry → Level → Off
 - Fully GDPR compliant
 - Uses Google Analytics 4 for anonymous metrics
 
 **Why telemetry?**
+
 - Helps us understand which features are used
 - Identifies bugs and errors to fix
 - Measures engagement and retention
@@ -105,8 +122,8 @@ See [README-Additional.md](README-Additional.md) for technical details
 
 ![HumanAgent MCP Extension Demo](high-res-demo.gif)
 
-*Complete demonstration of the HumanAgent MCP extension in action - showing real-time human-AI collaboration*
+_Complete demonstration of the HumanAgent MCP extension in action - showing real-time human-AI collaboration_
 
 ## Medium Article
-https://medium.com/@harperbenwilliam/stop-the-ai-chaos-why-human-in-the-loop-beats-fully-autonomous-coding-agents-eeb0ae17fde9
 
+https://medium.com/@harperbenwilliam/stop-the-ai-chaos-why-human-in-the-loop-beats-fully-autonomous-coding-agents-eeb0ae17fde9

--- a/ReadMeDev.md
+++ b/ReadMeDev.md
@@ -5,32 +5,43 @@
 VS Code extension that runs an HTTP MCP server on port 3737. The server handles three distinct endpoints to avoid connection conflicts:
 
 - `/mcp` - Server-Sent Events for VS Code webview
-- `/mcp-tools` - MCP protocol for VS Code extension registration  
+- `/mcp-tools` - MCP protocol for VS Code extension registration
 - `/HumanAgent` - Web interface for browser access
+
+Server lifecycle:
+
+- On VS Code close / window reload, the extension shuts down the standalone server.
+- On activation, the extension starts the server again.
+- The standalone server is copied into VS Code `globalStorage` and launched from there to avoid file locks during extension updates.
 
 ## Core Components
 
 **Extension Entry Point** (`src/extension.ts`)
+
 - Implements `McpServerDefinitionProvider` for VS Code integration
 - Manages workspace-specific session IDs using MD5 hash
 - Handles version-based cache invalidation for tool updates
 
-**MCP Server** (`src/mcp/server.ts`)  
+**MCP Server** (`src/mcp/server.ts`)
+
 - HTTP server handling MCP protocol and chat interfaces
 - Session-based tool override system
 - Real-time message broadcasting via SSE
 
 **Chat Management** (`src/mcp/chatManager.ts`)
+
 - Centralized message storage and session handling
 - Pending request tracking for AI-human interactions
 
 **Webview Provider** (`src/webview/chatWebviewProvider.ts`)
+
 - VS Code panel integration with SSE connection
 - Cog menu for session management and configuration
 
 ## Session System
 
 Sessions are tied to VS Code workspaces:
+
 - Session ID: `session-{uuid}` stored in VS Code global state
 - Workspace mapping: MD5 hash of workspace path
 - Tool overrides: Per-session tool configurations from `.vscode/HumanAgentOverride.json`
@@ -43,6 +54,7 @@ Sessions are tied to VS Code workspaces:
 4. Version changes in `McpHttpServerDefinition` force VS Code cache refresh
 
 Override file supports:
+
 - Tool description and schema customization
 - Message auto-appending (global and tool-specific)
 - Session-specific configurations
@@ -51,7 +63,7 @@ Override file supports:
 
 ```
 GET  /sessions                    - List active sessions
-POST /sessions/register           - Register session with overrides  
+POST /sessions/register           - Register session with overrides
 GET  /tools?sessionId=<id>        - Get tools for specific session
 GET  /debug/tools?sessionId=<id>  - Debug tool inspection
 POST /response                    - Submit human responses

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "humanagent-mcp",
-  "version": "0.0.1",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "humanagent-mcp",
-      "version": "0.0.1",
+      "version": "0.0.17",
       "dependencies": {
         "node-wav-player": "^1.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "humanagent-mcp",
   "displayName": "HumanAgent MCP",
   "description": "MCP server for chatting with a human agent",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "publisher": "3DTek-xyz",
   "icon": "HumanAgent_Icon_Square.png",
   "repository": {
@@ -142,7 +142,12 @@
         },
         "humanagent-mcp.logging.level": {
           "type": "string",
-          "enum": ["ERROR", "WARN", "INFO", "DEBUG"],
+          "enum": [
+            "ERROR",
+            "WARN",
+            "INFO",
+            "DEBUG"
+          ],
           "default": "INFO",
           "description": "Set the logging level for HumanAgent MCP server"
         },
@@ -152,7 +157,7 @@
           "description": "Enable audio notifications when AI agents send messages"
         },
         "humanagent-mcp.notifications.enableFlashing": {
-          "type": "boolean", 
+          "type": "boolean",
           "default": true,
           "description": "Enable visual flashing notifications when AI agents send messages"
         },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
-	"compilerOptions": {
-		"module": "Node16",
-		"target": "ES2022",
-		"lib": [
-			"ES2022"
-		],
-		"sourceMap": true,
-		"rootDir": "src",
-		"strict": true,   /* enable all strict type-checking options */
-		/* Additional Checks */
-		// "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-		// "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-		// "noUnusedParameters": true,  /* Report errors on unused parameters. */
-	}
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["node", "vscode", "mocha"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true /* enable all strict type-checking options */
+    /* Additional Checks */
+    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
+    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+  }
 }


### PR DESCRIPTION
Summary:
1. Fixed /response handling to avoid Windows-breaking debug writes and improved request validation.
2. Improved standalone server lifecycle: stop on VS Code close/reload and auto-shutdown when no sessions remain.
3. Prevented extension update/uninstall failures by launching the detached server from VS Code globalStorage instead of the installed extension folder.

Features:
1. Update-Safe Server Launch: Standalone server is staged into globalStorage (versioned) and old copies are best-effort cleaned up.
2. Idle Auto-Shutdown: Server schedules shutdown after the last session unregisters (configurable via HUMANAGENT_IDLE_SHUTDOWN_MS).
3. Graceful Deactivation Shutdown: Extension deactivation attempts HTTP /shutdown with PID-kill fallback to release ports reliably.

Changes:
1. Modified src/mcp/server.ts, Specifically removed hardcoded debug appendFileSync, added safe JSON parsing + required-field validation for /response, logged response length, added idle shutdown timer and session-aware scheduling.
2. Modified src/extension.ts, Specifically staged mcpStandalone.js into globalStorage for detached execution, replaced dynamic require fs.existsSync with imported fs, added server stop logic in deactivate() via /shutdown with fallback.
3. Modified tsconfig.json, Specifically enabled Node16 moduleResolution and added node/vscode/mocha types.
4. Modified package.json, Specifically bumped version 0.0.17 -> 0.0.18 and reformatted enum for logging level.
5. Modified README.md, README-Additional.md, ReadMeDev.md, Specifically documented server lifecycle behavior and added Windows port troubleshooting.
6. Modified package-lock.json, Specifically updated package version metadata.

Bug Fixes:
1. Fixed stuck “Waiting for your response...” caused by /response failing on Windows due to a macOS-only hardcoded file write.
2. Fixed extension update/uninstall failures caused by a detached server process locking files under the extension install directory.
3. Fixed ports remaining occupied after VS Code closes by shutting down the standalone server on deactivation and after last session unregisters.

Tests:
1. npx --yes @vscode/vsce package: PASSED.

Task: HumanAgent MCP Lifecycle + Windows /response Fix

NOTE:
This directly addressed https://github.com/3DTek-xyz/HumanAgent-MCP/issues/2 in v0.0.17,
Specifically where it always shows "⏳ Waiting for your response..." even after sending a response.